### PR TITLE
Add begin/end align,multline,gather as latex delimiters

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -111,6 +111,9 @@ endif
 syn include @markdownTex syntax/tex.vim
 syn region markdownMathJax start="\V$" end="\V$" keepend contains=@markdownTex
 syn region markdownMathJax start="\V$$" end="\V$$" keepend contains=@markdownTex
+syn region markdownMathJax start="\\begin{align}" end="\\end{align}" keepend contains=@markdownTex
+syn region markdownMathJax start="\\begin{multline}" end="\\end{multline}" keepend contains=@markdownTex
+syn region markdownMathJax start="\\begin{gather}" end="\\end{gather}" keepend contains=@markdownTex
 " these two line must come after escaping ('\\') syntax, since last match overrule
 " earlier one.
 syn region markdownMathJax start="\\\\\[" end="\\\\\]" keepend contains=@markdownTex


### PR DESCRIPTION
As supported by a python-markdown + python-markdown-math => html + mathjax workflow.

mathjax supports more than just these environments, but not being an expert on vim's syntax system I wasn't sure whether to paste them all in or whether there's a better option which is simple to implement.
